### PR TITLE
automatically install rosetta from the installer?

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -46,11 +46,6 @@ case "$(uname -s).$(uname -m)" in
         system=x86_64-darwin
         ;;
     Darwin.arm64|Darwin.aarch64)
-        # check for Rosetta 2 support
-        if ! [ -f /Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist ]; then
-          oops "Rosetta 2 is not installed on this ARM64 macOS machine. Run softwareupdate --install-rosetta then restart installation"
-        fi
-
         hash=@binaryTarball_x86_64-darwin@
         path=@tarballPath_x86_64-darwin@
         # eventually maybe: aarch64-darwin


### PR DESCRIPTION
I was hoping to get back to single-step Darwin installs via NixOS/nix#4289, so this PR is a draft at at folding nixos/nix#4305 into an automatic installer step. Curious what anyone thinks (particularly people who have m1 hardware in already like @matthewbauer @kloenk). I have a number of specific questions, but I guess I should start with the one that would moot the rest:  

Do you think it is acceptable/desirable to run `softwareupdate --install-rosetta` automatically at all?

<!-- 
Some specific questions:
-
- Is it acceptable to leave it rosetta behind if the user throws Nix out the window? 
- How long does this take? I suspect it is pretty fast because I saw someone post the download size.
- I saw someone report having to reinstall rosetta after the 11.0.1 OS update. Can anyone confirm/deny? Hoping this is mistaken or a bug, or Nix may need to be able to trigger this on any invocation? (Unless it can self-heal this, I assume nix-daemon will fall over on boot if this *is* a real/regular problem?)
...
 -->